### PR TITLE
build: adapt package id prefix to be customizable through environment variable

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -66,6 +66,7 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ''
 
 
   pack-nuget:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -115,3 +115,4 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ${{ github.repository_owner }}.

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -104,3 +104,4 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ${{ github.repository_owner }}.

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -55,6 +55,7 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ''
 
 
   pack-nuget:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -105,3 +105,4 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ${{ github.repository_owner }}.

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -56,6 +56,7 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ''
 
 
   pack-nuget:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -19,10 +19,12 @@ jobs:
             registry: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
             username: ${{ github.repository_owner }}
             token: GH_PUBLISH_TOKEN
+            prefix: ''
           - source: nuget
             registry: https://api.nuget.org/v3/index.json
             username: ${{ github.repository_owner }}
             token: NUGET_ORG_TOKEN
+            prefix: ${{ github.repository_owner }}.
     steps:
     - uses: kagekirin/gha-py-toolbox/macros/util/setup-system@main
       with:
@@ -66,3 +68,4 @@ jobs:
         GH_NUGET_USER: ${{ github.actor }}
         GH_NUGET_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
         UNITY_ASSEMBLY_PATH: ${{steps.install-unity.outputs.editor-path}}/Data/Managed
+        PACKAGE_PREFIX: ${{ matrix.prefix }}

--- a/Unity.Mathematics.Editor/Unity.Mathematics.Editor.csproj
+++ b/Unity.Mathematics.Editor/Unity.Mathematics.Editor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>KageKirin.Unity.Mathematics.Editor</PackageId>
+    <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics.Editor</PackageId>
     <Title>Unity.Mathematics.Editor</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package with a dependency on UnityEngine.dll and UnityEditor.dll</Description>
     <PackageTags>unity3d;mathematics</PackageTags>

--- a/Unity.Mathematics/Unity.Mathematics.NoDeps.csproj
+++ b/Unity.Mathematics/Unity.Mathematics.NoDeps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>KageKirin.Unity.Mathematics.NoDeps</PackageId>
+    <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics.NoDeps</PackageId>
     <Title>Unity.Mathematics.NoDeps</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package without dependency on UnityEngine.dll</Description>
     <PackageTags>unity3d;mathematics</PackageTags>

--- a/Unity.Mathematics/Unity.Mathematics.csproj
+++ b/Unity.Mathematics/Unity.Mathematics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>KageKirin.Unity.Mathematics</PackageId>
+    <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics</PackageId>
     <Title>Unity.Mathematics</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package with a dependency on UnityEngine.dll</Description>
     <PackageTags>unity3d;mathematics</PackageTags>

--- a/makefile
+++ b/makefile
@@ -1,16 +1,17 @@
 UNITY_ASSEMBLY_PATH?="/Applications/Unity/Hub/Editor/2022.3.47f1/Unity.app/Contents/Managed/"
+PACKAGE_PREFIX?="KageKirin."
 
 format: $(shell fd --max-depth=2 csproj$)
 	dos2unix -q -r $^
 
 restore: prepare
-	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) dotnet build -tl
+	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) PACKAGE_PREFIX=$(PACKAGE_PREFIX) dotnet build -tl
 
 build: restore
-	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) dotnet build -tl
+	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) PACKAGE_PREFIX=$(PACKAGE_PREFIX) dotnet build -tl
 
 pack: build
-	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) dotnet pack -tl
+	cd com.unity.mathematics; UNITY_ASSEMBLY_PATH=$(UNITY_ASSEMBLY_PATH) PACKAGE_PREFIX=$(PACKAGE_PREFIX) dotnet pack -tl
 	fd nupkg$$ -- com.unity.mathematics/.artifacts
 
 prepare:	\


### PR DESCRIPTION
- **build: change Unity.Mathematics package id prefix to to environment variable PACKAGE_PREFIX**
  note: PACKAGE_PREFIX must include '.'
  

- **build: change Unity.Mathematics.NoDeps package id prefix to to environment variable PACKAGE_PREFIX**
  note: PACKAGE_PREFIX must include '.'
  

- **build: change Unity.Mathematics.Editor package id prefix to to environment variable PACKAGE_PREFIX**
  note: PACKAGE_PREFIX must include '.'
  

- **refactor: pass PACKAGE_PREFIX in makefile**
  

- **refactor: pass PACKAGE_PREFIX as empty string in build-branch/build job**
  

- **refactor: pass PACKAGE_PREFIX as empty string in build-ci/build job**
  

- **refactor: pass PACKAGE_PREFIX as empty string in build-cron/build job**
  

- **refactor: pass PACKAGE_PREFIX as '<github.repository_owner>.' in build-branch/pack-nuget job**
  

- **refactor: pass PACKAGE_PREFIX as '<github.repository_owner>.' in build-ci/pack-nuget job**
  

- **refactor: pass PACKAGE_PREFIX as '<github.repository_owner>.' in build-cron/pack-nuget job**
  

- **refactor: pass PACKAGE_PREFIX from matrix parameters in publish-nuget workflow**
  details: no prefix for packages hosted on GitHub, <github.repository_owner> for packages hosted on Nuget.org
  