### PR TITLE
build: set fixed AssemblyName to allow Unity projects to reference the correct assembly

### DIFF
--- a/Unity.Mathematics.Editor/Unity.Mathematics.Editor.csproj
+++ b/Unity.Mathematics.Editor/Unity.Mathematics.Editor.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Unity.Mathematics.Editor</AssemblyName>
     <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics.Editor</PackageId>
     <Title>Unity.Mathematics.Editor</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package with a dependency on UnityEngine.dll and UnityEditor.dll</Description>

--- a/Unity.Mathematics/Unity.Mathematics.NoDeps.csproj
+++ b/Unity.Mathematics/Unity.Mathematics.NoDeps.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Unity.Mathematics</AssemblyName>
     <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics.NoDeps</PackageId>
     <Title>Unity.Mathematics.NoDeps</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package without dependency on UnityEngine.dll</Description>

--- a/Unity.Mathematics/Unity.Mathematics.csproj
+++ b/Unity.Mathematics/Unity.Mathematics.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Unity.Mathematics</AssemblyName>
     <PackageId>$(PACKAGE_PREFIX)Unity.Mathematics</PackageId>
     <Title>Unity.Mathematics</Title>
     <Description>NuGet packed from Unity.Mathematics UPM package with a dependency on UnityEngine.dll</Description>


### PR DESCRIPTION
- **build: set property AssemblyName to Unity.Mathematics in Unity.Mathematics project**
- **build: set property AssemblyName to Unity.Mathematics in Unity.Mathematics.NoDeps project**
- **build: set property AssemblyName to Unity.Mathematics.Editor in Unity.Mathematics.Editor project**
